### PR TITLE
docs: Add 2.0.0 release notes links

### DIFF
--- a/2.0.0_Release_notes.md
+++ b/2.0.0_Release_notes.md
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+
+## v2.0.0 Release Notes
+
+## admin-service
+https://github.com/frmscoe/admin-service/releases/tag/v2.0.0
+
+## rule-076
+https://github.com/frmscoe/rule-076/releases/tag/v2.0.0
+
+## rule-008
+https://github.com/frmscoe/rule-008/releases/tag/v2.0.0
+
+## rule-048
+https://github.com/frmscoe/rule-048/releases/tag/v2.0.0
+
+## rule-091
+https://github.com/frmscoe/rule-091/releases/tag/v2.0.0
+
+## rule-003
+https://github.com/frmscoe/rule-003/releases/tag/v2.0.0
+
+## rule-016
+https://github.com/frmscoe/rule-016/releases/tag/v2.0.0
+
+## rule-021
+https://github.com/frmscoe/rule-021/releases/tag/v2.0.0
+
+## rule-044
+https://github.com/frmscoe/rule-044/releases/tag/v2.0.0
+
+## rule-030
+https://github.com/frmscoe/rule-030/releases/tag/v2.0.0
+
+## rule-090
+https://github.com/frmscoe/rule-090/releases/tag/v2.0.0
+
+## rule-006
+https://github.com/frmscoe/rule-006/releases/tag/v2.0.0
+
+## rule-075
+https://github.com/frmscoe/rule-075/releases/tag/v2.0.0
+
+## rule-025
+https://github.com/frmscoe/rule-025/releases/tag/v2.0.0
+
+## rule-002
+https://github.com/frmscoe/rule-002/releases/tag/v2.0.0
+
+## rule-063
+https://github.com/frmscoe/rule-063/releases/tag/v2.0.0
+
+## rule-054
+https://github.com/frmscoe/rule-054/releases/tag/v2.0.0
+
+## rule-083
+https://github.com/frmscoe/rule-083/releases/tag/v2.0.0
+
+## rule-018
+https://github.com/frmscoe/rule-018/releases/tag/v2.0.0
+
+## rule-026
+https://github.com/frmscoe/rule-026/releases/tag/v2.0.0
+
+## rule-010
+https://github.com/frmscoe/rule-010/releases/tag/v2.0.0
+
+## rule-028
+https://github.com/frmscoe/rule-028/releases/tag/v2.0.0
+
+## rule-017
+https://github.com/frmscoe/rule-017/releases/tag/v2.0.0
+
+## rule-078
+https://github.com/frmscoe/rule-078/releases/tag/v2.0.0
+
+## rule-011
+https://github.com/frmscoe/rule-011/releases/tag/v2.0.0
+
+## rule-001
+https://github.com/frmscoe/rule-001/releases/tag/v2.0.0
+
+## rule-045
+https://github.com/frmscoe/rule-045/releases/tag/v2.0.0
+
+## rule-074
+https://github.com/frmscoe/rule-074/releases/tag/v2.0.0
+
+## rule-084
+https://github.com/frmscoe/rule-084/releases/tag/v2.0.0
+
+## rule-007
+https://github.com/frmscoe/rule-007/releases/tag/v2.0.0
+
+## rule-020
+https://github.com/frmscoe/rule-020/releases/tag/v2.0.0
+
+## rule-024
+https://github.com/frmscoe/rule-024/releases/tag/v2.0.0
+
+## rule-004
+https://github.com/frmscoe/rule-004/releases/tag/v2.0.0
+
+## rule-027
+https://github.com/frmscoe/rule-027/releases/tag/v2.0.0
+
+## tms-configuration
+https://github.com/frmscoe/tms-configuration/releases/tag/v2.0.0
+
+## rule-cli
+https://github.com/frmscoe/rule-cli/releases/tag/v2.0.0
+
+## performance-benchmark
+https://github.com/frmscoe/performance-benchmark/releases/tag/v2.0.0
+
+## rule-tests
+https://github.com/frmscoe/rule-tests/releases/tag/v2.0.0
+
+## workflows
+https://github.com/frmscoe/workflows/releases/tag/v2.0.0


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Add 2.0.0 release notes links

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done